### PR TITLE
HZC-521 - Regular printing of progress

### DIFF
--- a/src/main/java/com/hazelcast/cloud/Client.java
+++ b/src/main/java/com/hazelcast/cloud/Client.java
@@ -32,11 +32,13 @@ public class Client {
 
         IMap<String, String> map = client.getMap("map");
         Random random = new Random();
+        byte iterationCounter = 0;
         while (true) {
             int randomKey = random.nextInt(100_000);
             map.put("key-" + randomKey, "value-" + randomKey);
             map.get("key-" + random.nextInt(100_000));
-            if (randomKey % 10 == 0) {
+            if (++iterationCounter == 10) {
+                iterationCounter = 0;
                 System.out.println("Current map size: " + map.size());
             }
         }

--- a/src/main/java/com/hazelcast/cloud/Client.java
+++ b/src/main/java/com/hazelcast/cloud/Client.java
@@ -32,7 +32,7 @@ public class Client {
 
         IMap<String, String> map = client.getMap("map");
         Random random = new Random();
-        byte iterationCounter = 0;
+        int iterationCounter = 0;
         while (true) {
             int randomKey = random.nextInt(100_000);
             map.put("key-" + randomKey, "value-" + randomKey);

--- a/src/main/java/com/hazelcast/cloud/ClientWithSsl.java
+++ b/src/main/java/com/hazelcast/cloud/ClientWithSsl.java
@@ -41,11 +41,13 @@ public class ClientWithSsl {
 
         IMap<String, String> map = client.getMap("map");
         Random random = new Random();
+        byte iterationCounter = 0;
         while (true) {
             int randomKey = random.nextInt(100_000);
             map.put("key-" + randomKey, "value-" + randomKey);
             map.get("key-" + random.nextInt(100_000));
-            if (randomKey % 10 == 0) {
+            if (++iterationCounter == 10) {
+                iterationCounter = 0;
                 System.out.println("Current map size: " + map.size());
             }
         }

--- a/src/main/java/com/hazelcast/cloud/ClientWithSsl.java
+++ b/src/main/java/com/hazelcast/cloud/ClientWithSsl.java
@@ -41,7 +41,7 @@ public class ClientWithSsl {
 
         IMap<String, String> map = client.getMap("map");
         Random random = new Random();
-        byte iterationCounter = 0;
+        int iterationCounter = 0;
         while (true) {
             int randomKey = random.nextInt(100_000);
             map.put("key-" + randomKey, "value-" + randomKey);


### PR DESCRIPTION
As discussed with @huseyinbabal , here is the test result:

<img width="520" alt="image" src="https://user-images.githubusercontent.com/10501571/118964910-b4756400-b970-11eb-9914-44d09febcbbf.png">

```
INFO: hz.client_1 [test-01] [3.12.10] 

Members [1] {
	Member [100.119.172.240]:30793 - 740e7ad1-04e9-4a24-ab22-d47e4e4b8d7f
}

May 20, 2021 1:38:12 PM com.hazelcast.core.LifecycleService
INFO: hz.client_1 [test-01] [3.12.10] HazelcastClient 3.12.10 (20201019 - 74bc0be, b096a74) is CLIENT_CONNECTED
May 20, 2021 1:38:12 PM com.hazelcast.internal.diagnostics.Diagnostics
INFO: hz.client_1 [test-01] [3.12.10] Diagnostics disabled. To enable add -Dhazelcast.diagnostics.enabled=true to the JVM arguments.
May 20, 2021 1:38:12 PM com.hazelcast.client.impl.statistics.Statistics
INFO: Client statistics is enabled with period 3 seconds.
Connection Successful!
Now the map named 'map' will be filled with random entries.
Current map size: 2147
Current map size: 2157
Current map size: 2166
Current map size: 2176
Current map size: 2186
Current map size: 2195
Current map size: 2205
Current map size: 2215
Current map size: 2224
Current map size: 2233
Current map size: 2243
Current map size: 2253
```
