### PR TITLE
HZC-2013: Add SQL section to the 5.0 client sample

### DIFF
--- a/src/main/java/com/hazelcast/cloud/Client.java
+++ b/src/main/java/com/hazelcast/cloud/Client.java
@@ -64,15 +64,6 @@ public class Client {
      * @param client - a {@link HazelcastInstance} client.
      */
     private static void sqlExample(HazelcastInstance client) {
-        IMap<String, String> cities = client.getMap("cities");
-
-        System.out.println("Putting some data...");
-        cities.put("Australia", "Canberra");
-        cities.put("Croatia", "Zagreb");
-        cities.put("Czech Republic", "Prague");
-        cities.put("England", "London");
-        cities.put("Turkey", "Ankara");
-        cities.put("United States", "Washington, DC");
 
         System.out.println("Creating a mapping...");
         // See: https://docs.hazelcast.com/hazelcast/5.0/sql/mapping-to-maps
@@ -83,6 +74,20 @@ public class Client {
                 "'valueFormat' = 'java'," +
                 "'valueJavaClass' = 'java.lang.String')")) {
             System.out.println("The mapping has been created successfully.");
+        }
+
+        System.out.println("--------------------");
+        System.out.println("Inserting data via SQL...");
+
+        String insertQuery = "INSERT INTO cities VALUES" +
+            "('Australia','Canberra')," +
+            "('Croatia','Zagreb')," +
+            "('Czech Republic','Prague')," +
+            "('England','London')," +
+            "('Turkey','Ankara')," +
+            "('United States','Washington, DC');";
+        try (SqlResult ignored = client.getSql().execute(insertQuery)) {
+            System.out.println("The data has been inserted successfully.");
         }
 
         System.out.println("--------------------");

--- a/src/main/java/com/hazelcast/cloud/Client.java
+++ b/src/main/java/com/hazelcast/cloud/Client.java
@@ -6,13 +6,14 @@ import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.map.IMap;
+import com.hazelcast.sql.SqlResult;
+import com.hazelcast.sql.SqlRow;
 
 import static com.hazelcast.client.properties.ClientProperty.HAZELCAST_CLOUD_DISCOVERY_TOKEN;
 import static com.hazelcast.client.properties.ClientProperty.STATISTICS_ENABLED;
 
 /**
  * This is boilerplate application that configures client to connect Hazelcast Cloud cluster.
- * After successful connection, it puts random entries into the map.
  * <p>
  * See: <a href="https://docs.cloud.hazelcast.com/docs/java-client">https://docs.cloud.hazelcast.com/docs/java-client</a>
  */
@@ -27,6 +28,20 @@ public class Client {
         HazelcastInstance client = HazelcastClient.newHazelcastClient(config);
 
         System.out.println("Connection Successful!");
+
+        // the 'mapExample' is an example with an infinite loop inside, so if you'd like to try other examples,
+        // don't forget to comment out the following line
+        mapExample(client);
+
+        //sqlExample(client);
+    }
+
+    /**
+     * This example shows how to work with Hazelcast maps.
+     *
+     * @param client - a {@link HazelcastInstance} client.
+     */
+    private static void mapExample(HazelcastInstance client) {
         System.out.println("Now the map named 'map' will be filled with random entries.");
 
         IMap<String, String> map = client.getMap("map");
@@ -42,4 +57,58 @@ public class Client {
             }
         }
     }
+
+    /**
+     * This example shows how to work with Hazelcast SQL queries.
+     *
+     * @param client - a {@link HazelcastInstance} client.
+     */
+    private static void sqlExample(HazelcastInstance client) {
+        IMap<String, String> cities = client.getMap("cities");
+
+        System.out.println("Putting some data...");
+        cities.put("Australia", "Canberra");
+        cities.put("Croatia", "Zagreb");
+        cities.put("Czech Republic", "Prague");
+        cities.put("England", "London");
+        cities.put("Turkey", "Ankara");
+        cities.put("United States", "Washington, DC");
+
+        System.out.println("Creating a mapping...");
+        // See: https://docs.hazelcast.com/hazelcast/5.0/sql/mapping-to-maps
+        try (SqlResult ignored = client.getSql().execute(
+            "CREATE MAPPING cities TYPE IMap OPTIONS (" +
+                "'keyFormat' = 'java'," +
+                "'keyJavaClass' = 'java.lang.String'," +
+                "'valueFormat' = 'java'," +
+                "'valueJavaClass' = 'java.lang.String')")) {
+            System.out.println("The mapping has been created successfully.");
+        }
+
+        System.out.println("--------------------");
+        System.out.println("Retrieving all the data via SQL...");
+        try (SqlResult result = client.getSql().execute("SELECT * FROM cities")) {
+
+            for (SqlRow row : result) {
+                String country = row.getObject(0);
+                String city = row.getObject(1);
+                System.out.printf("%s - %s\n", country, city);
+            }
+        }
+
+        System.out.println("--------------------");
+        System.out.println("Retrieving a city name via SQL...");
+        try (SqlResult result = client.getSql()
+            .execute("SELECT __key, this FROM cities WHERE __key = ?", "United States")) {
+
+            for (SqlRow row : result) {
+                String country = row.getObject("__key");
+                String city = row.getObject("this");
+                System.out.printf("Country name: %s; City name: %s\n", country, city);
+            }
+        }
+        System.out.println("--------------------");
+        System.exit(0);
+    }
+
 }

--- a/src/main/java/com/hazelcast/cloud/ClientWithSsl.java
+++ b/src/main/java/com/hazelcast/cloud/ClientWithSsl.java
@@ -75,15 +75,6 @@ public class ClientWithSsl {
      * @param client - a {@link HazelcastInstance} client.
      */
     private static void sqlExample(HazelcastInstance client) {
-        IMap<String, String> cities = client.getMap("cities");
-
-        System.out.println("Putting some data...");
-        cities.put("Australia", "Canberra");
-        cities.put("Croatia", "Zagreb");
-        cities.put("Czech Republic", "Prague");
-        cities.put("England", "London");
-        cities.put("Turkey", "Ankara");
-        cities.put("United States", "Washington, DC");
 
         System.out.println("Creating a mapping...");
         // See: https://docs.hazelcast.com/hazelcast/5.0/sql/mapping-to-maps
@@ -94,6 +85,20 @@ public class ClientWithSsl {
                 "'valueFormat' = 'java'," +
                 "'valueJavaClass' = 'java.lang.String')")) {
             System.out.println("The mapping has been created successfully.");
+        }
+
+        System.out.println("--------------------");
+        System.out.println("Inserting data via SQL...");
+
+        String insertQuery = "INSERT INTO cities VALUES" +
+            "('Australia','Canberra')," +
+            "('Croatia','Zagreb')," +
+            "('Czech Republic','Prague')," +
+            "('England','London')," +
+            "('Turkey','Ankara')," +
+            "('United States','Washington, DC');";
+        try (SqlResult ignored = client.getSql().execute(insertQuery)) {
+            System.out.println("The data has been inserted successfully.");
         }
 
         System.out.println("--------------------");

--- a/src/main/java/com/hazelcast/cloud/ClientWithSsl.java
+++ b/src/main/java/com/hazelcast/cloud/ClientWithSsl.java
@@ -8,13 +8,14 @@ import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.config.SSLConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.map.IMap;
+import com.hazelcast.sql.SqlResult;
+import com.hazelcast.sql.SqlRow;
 
 import static com.hazelcast.client.properties.ClientProperty.HAZELCAST_CLOUD_DISCOVERY_TOKEN;
 import static com.hazelcast.client.properties.ClientProperty.STATISTICS_ENABLED;
 
 /**
  * This is boilerplate application that configures client to connect Hazelcast Cloud cluster.
- * After successful connection, it puts random entries into the map.
  * <p>
  * See: <a href="https://docs.cloud.hazelcast.com/docs/java-client">https://docs.cloud.hazelcast.com/docs/java-client</a>
  */
@@ -25,7 +26,8 @@ public class ClientWithSsl {
         Properties props = new Properties();
         props.setProperty("javax.net.ssl.keyStore", classLoader.getResource("client.keystore").toURI().getPath());
         props.setProperty("javax.net.ssl.keyStorePassword", "YOUR_SSL_PASSWORD");
-        props.setProperty("javax.net.ssl.trustStore", classLoader.getResource("client.truststore").toURI().getPath());
+        props.setProperty("javax.net.ssl.trustStore",
+            classLoader.getResource("client.truststore").toURI().getPath());
         props.setProperty("javax.net.ssl.trustStorePassword", "YOUR_SSL_PASSWORD");
         ClientConfig config = new ClientConfig();
         config.getNetworkConfig().setSSLConfig(new SSLConfig().setEnabled(true).setProperties(props));
@@ -37,6 +39,20 @@ public class ClientWithSsl {
         HazelcastInstance client = HazelcastClient.newHazelcastClient(config);
 
         System.out.println("Connection Successful!");
+
+        // the 'mapExample' is an example with an infinite loop inside, so if you'd like to try other examples,
+        // don't forget to comment out the following line
+        mapExample(client);
+
+        //sqlExample(client);
+    }
+
+    /**
+     * This example shows how to work with Hazelcast maps.
+     *
+     * @param client - a {@link HazelcastInstance} client.
+     */
+    private static void mapExample(HazelcastInstance client) {
         System.out.println("Now the map named 'map' will be filled with random entries.");
 
         IMap<String, String> map = client.getMap("map");
@@ -52,4 +68,58 @@ public class ClientWithSsl {
             }
         }
     }
+
+    /**
+     * This example shows how to work with Hazelcast SQL queries.
+     *
+     * @param client - a {@link HazelcastInstance} client.
+     */
+    private static void sqlExample(HazelcastInstance client) {
+        IMap<String, String> cities = client.getMap("cities");
+
+        System.out.println("Putting some data...");
+        cities.put("Australia", "Canberra");
+        cities.put("Croatia", "Zagreb");
+        cities.put("Czech Republic", "Prague");
+        cities.put("England", "London");
+        cities.put("Turkey", "Ankara");
+        cities.put("United States", "Washington, DC");
+
+        System.out.println("Creating a mapping...");
+        // See: https://docs.hazelcast.com/hazelcast/5.0/sql/mapping-to-maps
+        try (SqlResult ignored = client.getSql().execute(
+            "CREATE MAPPING cities TYPE IMap OPTIONS (" +
+                "'keyFormat' = 'java'," +
+                "'keyJavaClass' = 'java.lang.String'," +
+                "'valueFormat' = 'java'," +
+                "'valueJavaClass' = 'java.lang.String')")) {
+            System.out.println("The mapping has been created successfully.");
+        }
+
+        System.out.println("--------------------");
+        System.out.println("Retrieving all the data via SQL...");
+        try (SqlResult result = client.getSql().execute("SELECT * FROM cities")) {
+
+            for (SqlRow row : result) {
+                String country = row.getObject(0);
+                String city = row.getObject(1);
+                System.out.printf("%s - %s\n", country, city);
+            }
+        }
+
+        System.out.println("--------------------");
+        System.out.println("Retrieving a city name via SQL...");
+        try (SqlResult result = client.getSql()
+            .execute("SELECT __key, this FROM cities WHERE __key = ?", "United States")) {
+
+            for (SqlRow row : result) {
+                String country = row.getObject("__key");
+                String city = row.getObject("this");
+                System.out.printf("Country name: %s; City name: %s\n", country, city);
+            }
+        }
+        System.out.println("--------------------");
+        System.exit(0);
+    }
+
 }


### PR DESCRIPTION
Here is output example when the `sqlExample()` is uncommented:
```
Connection Successful!
Putting some data...
Creating a mapping...
The mapping has been created successfully.
--------------------
Retrieving all the data via SQL...
England - London
United States - Washington, DC
Czech Republic - Prague
Turkey - Ankara
Croatia - Zagreb
Australia - Canberra
--------------------
Retrieving a city name via SQL...
Country name: United States; City name: Washington, DC
--------------------
```