### PR TITLE
Terminate the JVM after the code sample

### DIFF
--- a/src/main/java/com/hazelcast/cloud/Client.java
+++ b/src/main/java/com/hazelcast/cloud/Client.java
@@ -41,6 +41,8 @@ public class Client {
         //nonStopMapExample(client);
 
         client.shutdown();
+
+        System.exit(0);
     }
 
     /**

--- a/src/main/java/com/hazelcast/cloud/ClientWithSsl.java
+++ b/src/main/java/com/hazelcast/cloud/ClientWithSsl.java
@@ -52,6 +52,8 @@ public class ClientWithSsl {
         //nonStopMapExample(client);
 
         client.shutdown();
+
+        System.exit(0);
     }
 
     /**


### PR DESCRIPTION
It seems that the exec plugin has some problems cleaning up the
daemon threads.

Adding an explicit exit at the end of the code samples solves
this problem.

The former code was producing an error like below when run
with mvn.

```
[WARNING] thread Thread[ForkJoinPool.commonPool-worker-3,5,com.hazelcast.cloud.ClientWithSsl] was interrupted but is still alive after waiting at least 15000msecs
[WARNING] thread Thread[ForkJoinPool.commonPool-worker-3,5,com.hazelcast.cloud.ClientWithSsl] will linger despite being asked to die via interruption
[WARNING] NOTE: 1 thread(s) did not finish despite being asked to  via interruption. This is not a problem with exec:java, it is a problem with the running code. Although not serious, it should be remedied.
```