### PR TITLE
Set platform encoding to UTF-8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,10 @@
         </dependency>
     </dependencies>
 
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>         
+
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
Remove maven warnings and improve stability across all platforms