### PR TITLE
HZC-7441: upgrade to 5.6.0 client 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast-enterprise</artifactId>
-            <version>5.6.0-SNAPSHOT</version>
+            <version>5.6.0</version>
         </dependency>
         <dependency>
             <groupId>dev.langchain4j</groupId>


### PR DESCRIPTION
`com.hazelcast:hazelcast-enterprise:5.6.0-SNAPSHOT -> com.hazelcast:hazelcast-enterprise:5.6.0`